### PR TITLE
Add docker integration

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,47 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: retreive code
+      uses: actions/checkout@v3
+    - name: Login to GitHub Packages Docker Registry
+      uses: docker/login-action@v1
+      with:
+         registry: ghcr.io
+         username: ${{ github.actor }}
+         password: ${{ secrets.GITHUB_TOKEN }}
+    # Currently required, because buildx doesn't support auto-push from docker
+    - name: Set up builder
+      uses: docker/setup-buildx-action@v1
+      id: buildx
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v2
+      with:
+        images: |
+          ghcr.io/${{ github.repository }}
+
+    - name: Build and push image
+      uses: docker/build-push-action@v2
+      with:
+        builder: ${{ steps.buildx.outputs.name }}
+        file: Dockerfile
+        push: true
+        platforms: linux/amd64
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.output.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt install build-essential cmake pkg-config meson libfftw3-dev libwebsocket
 RUN echo SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", MODE="0666", GROUP="plugdev", SYMLINK+="rtl_sdr" > /etc/udev/rules.d/99-rtl_sdr.rules
 RUN meson build --prefer-static
 RUN meson compile -C build
-COPY build/spectrumserver .
+COPY src/build/spectrumserver .
 COPY config.toml .
 EXPOSE 9002
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:latest
+WORKDIR /usr/src/phantomsdr
+
+RUN apt install build-essential cmake pkg-config meson libfftw3-dev libwebsocketpp-dev libflac++-dev zlib1g-dev libzstd-dev libboost-all-dev libopus-dev libliquid-dev
+RUN echo SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", MODE="0666", GROUP="plugdev", SYMLINK+="rtl_sdr" > /etc/udev/rules.d/99-rtl_sdr.rules
+RUN meson build --prefer-static
+RUN meson compile -C build
+COPY ./build .
+COPY ./config.toml .
+EXPOSE 9002
+
+CMD [ "rtl_sdr -f 145000000 -s 3200000 - | ./build/spectrumserver --config config.toml" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ RUN apt install build-essential cmake pkg-config meson libfftw3-dev libwebsocket
 RUN echo SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", MODE="0666", GROUP="plugdev", SYMLINK+="rtl_sdr" > /etc/udev/rules.d/99-rtl_sdr.rules
 RUN meson build --prefer-static
 RUN meson compile -C build
-COPY ./build .
-COPY ./config.toml .
+COPY build .
+COPY config.toml .
 EXPOSE 9002
 
 CMD [ "rtl_sdr -f 145000000 -s 3200000 - | ./build/spectrumserver --config config.toml" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,9 @@ WORKDIR /usr/src/phantomsdr
 
 RUN apt install build-essential cmake pkg-config meson libfftw3-dev libwebsocketpp-dev libflac++-dev zlib1g-dev libzstd-dev libboost-all-dev libopus-dev libliquid-dev
 RUN echo SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", MODE="0666", GROUP="plugdev", SYMLINK+="rtl_sdr" > /etc/udev/rules.d/99-rtl_sdr.rules
+COPY . .
 RUN meson build --prefer-static
 RUN meson compile -C build
-COPY src/build/spectrumserver .
-COPY config.toml .
 EXPOSE 9002
 
 CMD [ "rtl_sdr -f 145000000 -s 3200000 - | ./build/spectrumserver --config config.toml" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ubuntu:latest
 WORKDIR /usr/src/phantomsdr
 
 RUN apt update && apt install -y build-essential cmake pkg-config meson libfftw3-dev libwebsocketpp-dev libflac++-dev zlib1g-dev libzstd-dev libboost-all-dev libopus-dev libliquid-dev
+RUN mkdir -p /etc/udev/rules.d
 RUN echo SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", MODE="0666", GROUP="plugdev", SYMLINK+="rtl_sdr" > /etc/udev/rules.d/99-rtl_sdr.rules
 COPY . .
 RUN meson build --prefer-static

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 WORKDIR /usr/src/phantomsdr
 
-RUN apt install build-essential cmake pkg-config meson libfftw3-dev libwebsocketpp-dev libflac++-dev zlib1g-dev libzstd-dev libboost-all-dev libopus-dev libliquid-dev
+RUN apt update && apt install -y build-essential cmake pkg-config meson libfftw3-dev libwebsocketpp-dev libflac++-dev zlib1g-dev libzstd-dev libboost-all-dev libopus-dev libliquid-dev
 RUN echo SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", MODE="0666", GROUP="plugdev", SYMLINK+="rtl_sdr" > /etc/udev/rules.d/99-rtl_sdr.rules
 COPY . .
 RUN meson build --prefer-static

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:latest
 WORKDIR /usr/src/phantomsdr
 
-RUN apt update && apt install -y build-essential cmake pkg-config meson libfftw3-dev libwebsocketpp-dev libflac++-dev zlib1g-dev libzstd-dev libboost-all-dev libopus-dev libliquid-dev
+RUN apt update && apt install -y build-essential git cmake pkg-config meson libfftw3-dev libwebsocketpp-dev libflac++-dev zlib1g-dev libzstd-dev libboost-all-dev libopus-dev libliquid-dev
 RUN mkdir -p /etc/udev/rules.d
 RUN echo SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", MODE="0666", GROUP="plugdev", SYMLINK+="rtl_sdr" > /etc/udev/rules.d/99-rtl_sdr.rules
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt install build-essential cmake pkg-config meson libfftw3-dev libwebsocket
 RUN echo SUBSYSTEM=="usb", ATTRS{idVendor}=="0bda", ATTRS{idProduct}=="2838", MODE="0666", GROUP="plugdev", SYMLINK+="rtl_sdr" > /etc/udev/rules.d/99-rtl_sdr.rules
 RUN meson build --prefer-static
 RUN meson compile -C build
-COPY build .
+COPY build/spectrumserver .
 COPY config.toml .
 EXPOSE 9002
 

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -8,4 +8,5 @@ services:
     volumes:
       - "./config.toml:/usr/src/phantomsdr/config.toml"
     devices:
+      # RTL-SDR devices
       - /dev/bus/usb:/dev/bus/usb

--- a/docker-compose.sample.yml
+++ b/docker-compose.sample.yml
@@ -1,0 +1,11 @@
+version: "3.8"
+services:
+  phantomsdr:
+    container_name: phantomsdr
+    image: ghcr.io/f4iey/PhantomSDR:latest
+    ports:
+      - "9002:9002"
+    volumes:
+      - "./config.toml:/usr/src/phantomsdr/config.toml"
+    devices:
+      - /dev/bus/usb:/dev/bus/usb


### PR DESCRIPTION
This PR allows PhantomSDR to run inside a docker container, with RTL-SDR device passthrough, for a one-click deploy